### PR TITLE
Add privacy policy for Discord Link Protector extension

### DIFF
--- a/privacy-policy.md
+++ b/privacy-policy.md
@@ -1,0 +1,39 @@
+# Privacy Policy
+
+## Discord Link Protector
+
+Last updated: 2026
+
+## Overview
+Discord Link Protector is a browser extension designed to detect and block malicious or suspicious links within Discord web pages.
+
+## Data Collection
+This extension does NOT collect, store, sell, or transmit any personal data to external servers.
+
+We do not collect:
+- Personal information
+- Authentication information
+- Messages or personal communications
+- Browsing history
+- Financial or sensitive data
+
+## Local Data Storage
+The extension may store the following locally on your device using browser storage:
+- User settings (on/off toggle)
+- Blocked domains list
+- Extension preferences
+
+This data never leaves your device.
+
+## How the Extension Works
+The extension scans visible Discord web page content locally in your browser to detect suspicious or malicious links. All processing happens on-device.
+
+## Third-Party Sharing
+We do not share any user data with third parties.
+
+## Security
+All detection and filtering occurs locally within the browser environment. No external servers are used for scanning.
+
+## Contact
+If you have questions or security concerns, join our support server:
+https://discord.gg/4pnWZhhw4


### PR DESCRIPTION
Added a privacy policy for the Discord Link Protector extension, detailing data collection, local storage, functionality, and security measures.